### PR TITLE
Fix migration error when table already exists

### DIFF
--- a/data/migrations/20190816003544_create_tracks_table.js
+++ b/data/migrations/20190816003544_create_tracks_table.js
@@ -1,9 +1,14 @@
-exports.up = knex =>
-    knex.schema.createTable("tracks", tracks => {
+exports.up = async knex => {
+    const hasTable = await knex.schema.hasTable("tracks")
+    if (hasTable) return
+
+    return knex.schema.createTable("tracks", tracks => {
         tracks.increments()
         tracks
             .string("title")
             .notNullable()
             .unique()
     })
+}
+
 exports.down = knex => knex.schema.dropTableIfExists("tracks")

--- a/data/migrations/20190821162815_create_users_table.js
+++ b/data/migrations/20190821162815_create_users_table.js
@@ -1,4 +1,7 @@
-exports.up = function(knex) {
+exports.up = async knex => {
+    const hasTable = await knex.schema.hasTable("users")
+    if (hasTable) return
+
     return knex.schema.createTable("users", users => {
         users.increments()
 

--- a/data/migrations/20190822153319_create_tasks_table.js
+++ b/data/migrations/20190822153319_create_tasks_table.js
@@ -1,4 +1,7 @@
-exports.up = function(knex) {
+exports.up = async knex => {
+    const hasTable = await knex.schema.hasTable("tasks")
+    if (hasTable) return
+
     return knex.schema.createTable("tasks", tasks => {
         tasks.increments()
         tasks.string("title", 255).notNullable()

--- a/data/migrations/20190822153830_create_resources_table.js
+++ b/data/migrations/20190822153830_create_resources_table.js
@@ -1,4 +1,7 @@
-exports.up = function(knex) {
+exports.up = async knex => {
+    const hasTable = await knex.schema.hasTable("users")
+    if (hasTable) return
+
     return knex.schema.createTable("resources", resources => {
         resources.increments()
         resources

--- a/data/migrations/20190822155403_create_steps_table.js
+++ b/data/migrations/20190822155403_create_steps_table.js
@@ -1,4 +1,7 @@
-exports.up = function(knex) {
+exports.up = async knex => {
+    const hasTable = await knex.schema.hasTable("users")
+    if (hasTable) return
+
     return knex.schema.createTable("steps", steps => {
         steps.increments()
         steps

--- a/data/migrations/20190822155841_create_user_steps_completed_table.js
+++ b/data/migrations/20190822155841_create_user_steps_completed_table.js
@@ -1,4 +1,7 @@
-exports.up = function(knex) {
+exports.up = async knex => {
+    const hasTable = await knex.schema.hasTable("users")
+    if (hasTable) return
+
     return knex.schema.createTable("user_steps_completed", completed => {
         completed.increments()
         completed

--- a/data/migrations/20190823111832_create_tasks_track_table.js
+++ b/data/migrations/20190823111832_create_tasks_track_table.js
@@ -1,4 +1,7 @@
-exports.up = function(knex) {
+exports.up = async knex => {
+    const hasTable = await knex.schema.hasTable("users")
+    if (hasTable) return
+
     return knex.schema.createTable("tasks_tracks", tbl => {
         tbl.increments()
         tbl.integer("tracks_id")


### PR DESCRIPTION
# Description
This fixes that migration/rollback issue by making sure a table doesn't already exist before trying to create it.

E2E tests will pass once #8 is merged.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Change Status

-   [X] Complete, tested, ready to review and merge
-   [ ] Complete, but not tested (may need new tests)
-   [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

-   [X] Manual test
