### PR TITLE
Fix a query `join` that came before a `where`

### DIFF
--- a/src/model/users.js
+++ b/src/model/users.js
@@ -11,8 +11,8 @@ const findUsersBy = filter => db("users").where(filter)
 
 const findUserNoPassword = userId => {
     return db("users")
-        .join("tracks", "tracks.id", "users.tracks_id")
         .where({ "users.id": userId })
+        .join("tracks", "tracks.id", "users.tracks_id")
         .select(
             "first_name",
             "last_name",


### PR DESCRIPTION
# Bugfix

## Description
`/users/:userId` wasn't working because a `join` query was running before a `where` query. This fixes that. Manually tested.