### PR TITLE
changes join in findUserNoPassword to be leftJoin instead

### DIFF
--- a/src/model/users.js
+++ b/src/model/users.js
@@ -35,7 +35,7 @@ const findUsersBy = filter => db("users").where(filter)
 const findUserNoPassword = userId => {
     return db("users")
         .where({ "users.id": userId })
-        .join("tracks", "tracks.id", "users.tracks_id")
+        .leftJoin("tracks", "tracks.id", "users.tracks_id")
         .select(
             "first_name",
             "last_name",


### PR DESCRIPTION
# Description

Fixes 
![get-user-error](https://user-images.githubusercontent.com/32152604/65457404-5b9ea280-de00-11e9-8975-b3448bc7dfc9.png)
 (issue)

When the user logs in as a coach, the fetch user action was failing with an error message of "Cannot read property tracks_id of undefined" . Adding a left join to the findUserNoPassword model function fixes that error message 

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Change Status

-   [x] Complete, tested, ready to review and merge
-   [ ] Complete, but not tested (may need new tests)
-   [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

-   [x] Runs locally
-   [x] e2e tests

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] My code has been reviewed by at least one peer
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] There are no merge conflicts
